### PR TITLE
feat(publish): GitHub Packages only — drop npmjs.com from trust boundary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Release
 
-# Creates a GitHub Release object (tag + changelog + signed artifacts) on
-# every push to main. npm publishing is handled separately by version.yml;
-# this workflow owns the signed-tarball path + SLSA Level 3 provenance
-# attestation. See .genie/wishes/genie-supply-chain-signing/WISH.md.
+# Creates a GitHub Release object (tag + changelog + signed artifacts) AND
+# publishes the same tarball to GitHub Packages on every `v*` tag push.
+# This workflow owns the signed-tarball path + SLSA Level 3 provenance
+# attestation + the only publish channel (npm.pkg.github.com). npmjs.com is
+# NOT a publish target — explicit trust-model decision after the April 2026
+# CanisterWorm incident. See README "Why GitHub Packages".
 #
 # Signing is cosign keyless (OIDC via GitHub Actions) — KEYLESS ONLY.
 # There is no long-lived fallback key: no private key in repo secrets, no
@@ -20,13 +22,14 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
 
 permissions:
   contents: write
   id-token: write   # required for cosign keyless OIDC token exchange
   actions: read     # required by slsa-github-generator to read workflow run metadata
+  packages: write   # required to publish the tarball to GitHub Packages (npm.pkg.github.com)
 
 jobs:
   release:
@@ -333,3 +336,86 @@ jobs:
           echo "OK: slsa-verifier rejected mutated tarball"
 
           rm -f "${MUTATED}"
+
+  # Publish to GitHub Packages (npm.pkg.github.com) ONLY — npmjs.com is
+  # explicitly excluded from the trust boundary. This job runs AFTER verify
+  # passes, so only cosign-verified + SLSA-attested + tamper-resistant
+  # tarballs reach the registry.
+  publish-github-packages:
+    name: Publish to GitHub Packages
+    needs: [release, provenance, verify]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # for provenance on npm publish (Node 22+ supports this)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Setup Node for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@automagik-dev'
+
+      - name: Install dependencies
+        env:
+          BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-cache-${{ github.run_id }}-${{ github.run_attempt }}
+        run: bun install
+
+      - name: Build CLI
+        run: bun run build
+
+      - name: Download signed tarball from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ needs.release.outputs.tag }}"
+          mkdir -p /tmp/publish
+          cd /tmp/publish
+          gh release download "${TAG}" \
+            --repo "${{ github.repository }}" \
+            --pattern '*.tgz'
+          ls -la
+
+      - name: Publish signed tarball to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd /tmp/publish
+          TARBALL=$(ls *.tgz | head -1)
+          if [ -z "${TARBALL}" ]; then
+            echo "No tarball found from release download" >&2
+            exit 1
+          fi
+          echo "Publishing ${TARBALL} to https://npm.pkg.github.com"
+          # --provenance adds an npm-side provenance attestation (Node 22+) on
+          # top of our SLSA L3 + cosign layers. Triple-attested supply chain:
+          # cosign identity pin + SLSA generator + npm provenance.
+          npm publish "${TARBALL}" --provenance --access public
+
+      - name: Verify package visible on GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          # Retry up to 6 times (60s total) because GitHub Packages index
+          # takes a few seconds to propagate after publish.
+          for i in 1 2 3 4 5 6; do
+            if npm view "@automagik-dev/aegis@${VERSION}" --registry=https://npm.pkg.github.com version 2>/dev/null; then
+              echo "OK: @automagik-dev/aegis@${VERSION} visible on GitHub Packages"
+              exit 0
+            fi
+            echo "Attempt ${i}/6: package not visible yet, sleeping 10s..."
+            sleep 10
+          done
+          echo "FAIL: @automagik-dev/aegis@${VERSION} never appeared on GitHub Packages after 60s" >&2
+          exit 1

--- a/.npmrc.example
+++ b/.npmrc.example
@@ -1,0 +1,25 @@
+# .npmrc for installing @automagik-dev/aegis from GitHub Packages.
+#
+# aegis is published ONLY to GitHub Packages (npm.pkg.github.com), never to
+# npmjs.com. This is a deliberate trust-model decision after the April 2026
+# CanisterWorm / TeamPCP npm compromise. See README for context.
+#
+# To install @automagik-dev/aegis you need:
+#
+# 1. A GitHub Personal Access Token with `read:packages` scope.
+#    Create at: https://github.com/settings/tokens (classic), or
+#    for finer-grained control: https://github.com/settings/personal-access-tokens/new
+#
+# 2. This file copied to ~/.npmrc (global) OR placed in the project root.
+#    Replace YOUR_GITHUB_TOKEN_HERE below with your actual PAT.
+#
+# Route only the @automagik-dev scope to GitHub Packages; everything else
+# stays on npmjs.com (for the rest of your dependencies).
+
+@automagik-dev:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN_HERE
+
+# After this file is in place:
+#   npm install @automagik-dev/aegis
+#   # or one-shot:
+#   npx @automagik-dev/aegis scan --all-homes --root "$PWD"

--- a/README.md
+++ b/README.md
@@ -10,23 +10,60 @@ Spun out of `@automagik/genie sec` after the April 2026 CanisterWorm / TeamPCP i
 
 ---
 
+## Installation
+
+`aegis` is published **only** to GitHub Packages (`npm.pkg.github.com`), never to `npmjs.com`. This is a deliberate trust-model decision — see [Why GitHub Packages](#why-github-packages) below.
+
+One-time setup:
+
+```bash
+# 1. Create a GitHub PAT with `read:packages` scope:
+#    https://github.com/settings/tokens  (classic — pick "read:packages")
+#    or a fine-grained token scoped to automagik-dev with Packages: Read.
+
+# 2. Copy the shipped .npmrc.example to your home directory and fill in the token:
+cat > ~/.npmrc <<EOF
+@automagik-dev:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT_HERE
+EOF
+chmod 600 ~/.npmrc
+```
+
 ## Quick start
 
 ```bash
 # One-shot scan
-npx -y @automagik/aegis scan --all-homes --root "$PWD"
+npx @automagik-dev/aegis scan --all-homes --root "$PWD"
 
 # Interactive incident fix (scan → kill processes → purge caches → reinstall clean → re-scan)
-npx -y @automagik/aegis fix
+npx @automagik-dev/aegis fix
 
 # Verify your installed binary is genuine (cosign keyless + SLSA L3)
-npx -y @automagik/aegis verify-install
+npx @automagik-dev/aegis verify-install
 ```
 
 Exit codes:
 - `0` — clean and complete
 - `1` — findings present
 - `2` — clean but incomplete (capped roots, banner at top tells you what was skipped)
+
+## Why GitHub Packages
+
+`@automagik/genie sec` (the scanner `aegis` was spun out of) shipped via `npmjs.com`. During the April 2026 CanisterWorm / TeamPCP incident, the weaponization vector was `npmjs.com` itself — compromised publishes of multiple packages propagated within hours. **Our scanner was being shipped through the same pipe that got compromised.**
+
+`aegis` is published only to GitHub Packages, tying the trust boundary of the tool to the same platform that hosts the code, the PRs, the cosign OIDC identity, the SLSA provenance, and the release workflow. The chain is:
+
+1. Code review on GitHub (2-officer Namastex sign-off)
+2. Tag push triggers `.github/workflows/release.yml`
+3. Cosign keyless signs the tarball (OIDC identity tied to this workflow path)
+4. SLSA L3 provenance attestation generated
+5. Tamper-detection self-test proves both verifiers reject a mutated byte
+6. GitHub Release created with signed assets
+7. Same tarball published to GitHub Packages with `npm publish --provenance` (npm provenance = 3rd attestation layer on top of cosign + SLSA)
+
+Triple-attested supply chain, one platform boundary. No `npmjs.com` in the trust path.
+
+**Cost of this decision:** users need a GitHub PAT to install (even for public packages, GitHub Packages requires auth). We believe the trust gain outweighs the install friction. See [`.npmrc.example`](.npmrc.example).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "@automagik/aegis",
+  "name": "@automagik-dev/aegis",
   "version": "0.1.0",
-  "description": "npm supply-chain incident-response CLI — scan, fix, remediate, verify. Spun out of @automagik/genie sec after the April 2026 CanisterWorm incident.",
+  "description": "npm supply-chain incident-response CLI — scan, fix, remediate, verify. Published via GitHub Packages only (trust-model decision after the April 2026 CanisterWorm incident). Spun out of @automagik/genie sec.",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "type": "module",
   "bin": {
     "aegis": "./dist/cli.js"


### PR DESCRIPTION
Published exclusively to GitHub Packages (npm.pkg.github.com). npmjs.com is NOT a publish target.

## Why

The April 2026 CanisterWorm / TeamPCP incident weaponized npmjs.com as the propagation vector. Publishing a security tool through the same pipe that got compromised no longer holds.

## Changes

### Package scope
- @automagik/aegis → @automagik-dev/aegis (GitHub Packages requires scope = repo owner)
- publishConfig added pointing to https://npm.pkg.github.com with public access

### Release workflow
- Trigger: push to main → push tags v* (aegis has no main branch)
- Added packages: write permission
- New publish-github-packages job runs AFTER cosign + SLSA + tamper-detection self-test — only verified tarballs reach the registry
- Uses npm publish --provenance (Node 22+) → triple-attested chain: cosign identity + SLSA L3 + npm provenance
- Post-publish visibility check with 60s retry loop

### Docs
- README Quick start rewritten for .npmrc setup
- README new 'Why GitHub Packages' section explaining trust-boundary decision + 7-step release chain + install-friction trade-off
- .npmrc.example with annotated setup

## Validation
- bun run typecheck clean
- bun test: 129 pass / 0 fail / 422 expect() calls
- bun run build: dist/cli.js 99.59 KB

## Next
- Merge → tag v0.1.0 → release workflow runs end-to-end → proves @automagik-dev/aegis visible on GitHub Packages with full triple-attestation

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package now published to GitHub Packages with supply-chain security verification and SLSA provenance support

* **Documentation**
  * Updated installation guide with GitHub Packages authentication setup
  * Added npm configuration documentation for scoped package access

* **Chores**
  * Package renamed to `@automagik-dev/aegis`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->