### PR TITLE
fix(rebrand): sweep remaining genie sec residuals (round 2)

### DIFF
--- a/.github/ISSUE_TEMPLATE/signing-key-fingerprint.md
+++ b/.github/ISSUE_TEMPLATE/signing-key-fingerprint.md
@@ -78,13 +78,13 @@ slsa-verifier verify-artifact <artifact> \
   --source-uri github.com/automagik-dev/aegis
 
 # End-to-end
-genie sec verify-install
+aegis verify-install
 ```
 
 ## Reporting a Suspected Compromise
 
 If the certificate-identity or OIDC issuer appears altered, or a release
 verifies under an identity that does NOT appear here, email
-`security@namastex.com` immediately. Do NOT run `genie sec remediate --apply`
+`security@namastex.com` immediately. Do NOT run `aegis remediate --apply`
 against any host until a new pinning issue is filed and the three channels
 re-converge.

--- a/docs/incident-response/canisterworm.md
+++ b/docs/incident-response/canisterworm.md
@@ -773,17 +773,17 @@ jq -r '.status' /tmp/rescan.json
 
 ### 11.6 Escalation — rollback
 
-Use `genie sec rollback <scan_id>` when `aegis remediate --apply` completed but broke something on the host. Rollback walks the audit log in reverse, restoring every quarantined item to its original path with sha256-verified content.
+Use `aegis rollback <scan_id>` when `aegis remediate --apply` completed but broke something on the host. Rollback walks the audit log in reverse, restoring every quarantined item to its original path with sha256-verified content.
 
 **When to reach for this:** a service fails to start after remediation, a legitimate config file was quarantined, a dependency your application needs is gone. Rollback is safe — it only touches items the audit log recorded.
 
 ```bash
 # Bulk rollback: walks $GENIE_SEC_AUDIT_LOG in reverse for this scan_id.
-genie sec rollback "$SCAN_ID"
+aegis rollback "$SCAN_ID"
 
 # Per-item: if you only need to restore a specific quarantine id.
-genie sec quarantine list
-genie sec restore <quarantine-id>
+aegis quarantine list
+aegis restore <quarantine-id>
 ```
 
 ### 11.7 Escalation — `--unsafe-unverified`

--- a/docs/security/key-rotation.md
+++ b/docs/security/key-rotation.md
@@ -40,7 +40,7 @@ There is no routine calendar rotation. Rotation is driven by events, not time.
 | Minimum approvers | Two Namastex security officers (independent GitHub accounts)                                    |
 | Pinning channels  | `SECURITY.md`, `/.well-known/security.txt`, pinned GitHub issue                                 |
 | Grace period      | Minimum 72 hours in which the OLD and NEW identities both verify                                |
-| Retirement test   | `genie sec verify-install` against a post-rotation release MUST exit 0                          |
+| Retirement test   | `aegis verify-install` against a post-rotation release MUST exit 0                          |
 | Audit trail       | Rotation PR signed by both officers; the pinned issue records the `Filed by (GPG fingerprint)`. |
 
 If any of the five constraints above cannot be met, the rotation does not
@@ -88,10 +88,10 @@ ship. Do NOT reduce the grace period to "fix" a broken window.
    accept BOTH the old and new certificate identities. In practice that means
    keeping the old entry in `SECURITY.md` under a `## Previous pinning`
    heading so operators running the previous release do not fail
-   `genie sec verify-install`.
+   `aegis verify-install`.
 2. The pinned issue is updated with the old value under its
    `## Previous pinning` section — never deleted.
-3. Operators running `genie sec verify-install --offline` during the grace
+3. Operators running `aegis verify-install --offline` during the grace
    period should see `verified_at` timestamps newer than the rotation epoch.
    Any operator whose `verified_at` predates the rotation is instructed to
    pull the new release.
@@ -111,7 +111,7 @@ ship. Do NOT reduce the grace period to "fix" a broken window.
 
 The rotation procedure MUST be practiced at least once per quarter using
 throwaway test identities. A successful dry-run ends with
-`genie sec verify-install` returning exit 0 against a test-release bundle
+`aegis verify-install` returning exit 0 against a test-release bundle
 signed by the rehearsed identity.
 
 ### Goal
@@ -147,12 +147,12 @@ EOF
 # 4. Exercise the verify-install command. Expected: exit 4 (provenance
 #    invalid) because the drill provenance is intentionally invalid. Good —
 #    that proves the failure mode works. The cosign step should succeed.
-genie sec verify-install --bundle-dir "${DRILL}" --json || echo "exit=$?"
+aegis verify-install --bundle-dir "${DRILL}" --json || echo "exit=$?"
 
 # 5. Flip one byte in the tarball and re-run. Expected: exit 2 (signature
 #    invalid). Good — tamper detection works end-to-end.
 printf '\x01' | dd of=drill.tgz bs=1 count=1 conv=notrunc
-genie sec verify-install --bundle-dir "${DRILL}" --json || echo "exit=$?"
+aegis verify-install --bundle-dir "${DRILL}" --json || echo "exit=$?"
 
 # 6. Clean up.
 rm -rf "${DRILL}"
@@ -190,4 +190,4 @@ The following have bitten prior rotations and MUST NOT be repeated:
 - `src/sec/unsafe-verify.ts` — the `--unsafe-unverified` contract that
   operators fall back on if a rotation goes sideways.
 - `scripts/verify-release.sh` — the local verification script that mirrors
-  `genie sec verify-install`.
+  `aegis verify-install`.

--- a/scripts/aegis-fix.cjs
+++ b/scripts/aegis-fix.cjs
@@ -27,11 +27,11 @@
  * evidence subset defined there.
  *
  * Usage:
- *   genie sec fix                    # default: scan → plan → confirm → apply → reinstall → rescan
- *   genie sec fix --yes              # non-interactive
- *   genie sec fix --skip-reinstall   # skip step 5 (keep current binary)
- *   genie sec fix --skip-rescan      # skip step 6
- *   genie sec fix --json             # machine-readable final summary
+ *   aegis fix                    # default: scan → plan → confirm → apply → reinstall → rescan
+ *   aegis fix --yes              # non-interactive
+ *   aegis fix --skip-reinstall   # skip step 5 (keep current binary)
+ *   aegis fix --skip-rescan      # skip step 6
+ *   aegis fix --json             # machine-readable final summary
  */
 
 const { spawnSync } = require('node:child_process');
@@ -91,7 +91,7 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  process.stdout.write(`Usage: genie sec fix [options]
+  process.stdout.write(`Usage: aegis fix [options]
 
 One-shot CanisterWorm incident remediation. Orchestrates the full cleanup
 playbook so you do not have to chain scan → plan → apply → reinstall → rescan
@@ -114,7 +114,7 @@ Options:
   --help, -h               Show this help.
 
 Recovery paths (none of this is destructive-without-recourse):
-  - Quarantined files/dirs: genie sec restore <quarantine-id>
+  - Quarantined files/dirs: aegis restore <quarantine-id>
   - Purged caches: re-fetched from registry on next install
   - Reinstalled binary: the old compromised one is removed from global,
     but the quarantine still has its bytes if you need them.
@@ -259,7 +259,7 @@ function runScan() {
     }
   } else {
     process.stderr.write(
-      `  ${TTY.yellow}running as user $(id -un) — for full coverage of other homes + /etc/cron + /etc/systemd + all PIDs, re-run under ${TTY.bold}sudo -E env "PATH=$PATH" genie sec fix${TTY.reset}\n`,
+      `  ${TTY.yellow}running as user $(id -un) — for full coverage of other homes + /etc/cron + /etc/systemd + all PIDs, re-run under ${TTY.bold}sudo -E env "PATH=$PATH" aegis fix${TTY.reset}\n`,
     );
   }
   const scanArgs = [SCAN_SCRIPT, '--json', '--no-progress', '--redact'];
@@ -477,7 +477,7 @@ function showPlanSummary(plan, options, envelope) {
       SEVERITY.DESTRUCTIVE,
       'REMOVE INSTALL DIR',
       path,
-      'clean binary reinstalls in step 5; malicious bytes are quarantined (genie sec restore)',
+      'clean binary reinstalls in step 5; malicious bytes are quarantined (aegis restore)',
     );
   }
 
@@ -827,7 +827,7 @@ function main() {
       warn(`Residual findings remain. status=${status} score=${score}/100 — review manually.`);
     }
   } else {
-    info('re-scan skipped or failed — run `genie sec scan --all-homes --redact` to confirm.');
+    info('re-scan skipped or failed — run `aegis scan --all-homes --redact` to confirm.');
   }
 
   if (options.json) {
@@ -863,8 +863,8 @@ function main() {
   }
 
   info('Recovery commands:');
-  info('  • Restore a quarantined item: genie sec restore <id>');
-  info(`  • Rollback everything for this scan: genie sec rollback ${envelope.scan_id || '<scan-id>'}`);
+  info('  • Restore a quarantined item: aegis restore <id>');
+  info(`  • Rollback everything for this scan: aegis rollback ${envelope.scan_id || '<scan-id>'}`);
   info('  • Rotate credentials the payload may have read:');
   info('    npm token: https://www.npmjs.com/settings/<you>/tokens');
   info('    GitHub PAT: https://github.com/settings/tokens');

--- a/scripts/aegis-remediate.cjs
+++ b/scripts/aegis-remediate.cjs
@@ -3,16 +3,16 @@
  * sec-remediate.cjs
  *
  * Reversible, auditable remediation pathway for findings produced by
- * `genie sec scan`. Sibling payload to `scripts/sec-scan.cjs` — it never
+ * `aegis scan`. Sibling payload to `scripts/sec-scan.cjs` — it never
  * detects, it never deletes, it only quarantines, prints rotation guidance,
  * or (with explicit consent) sends a SIGTERM to a pre-listed PID.
  *
  * Usage:
- *   genie sec remediate --dry-run --scan-id <ulid>
- *   genie sec remediate --dry-run --scan-report <path>
- *   genie sec remediate --apply --plan <path>
- *   genie sec remediate --resume <resume-file>
- *   genie sec restore <quarantine-id>
+ *   aegis remediate --dry-run --scan-id <ulid>
+ *   aegis remediate --dry-run --scan-report <path>
+ *   aegis remediate --apply --plan <path>
+ *   aegis remediate --resume <resume-file>
+ *   aegis restore <quarantine-id>
  *
  * Exit codes:
  *   0 = success (dry-run wrote plan, apply finished cleanly, restore succeeded)
@@ -383,7 +383,7 @@ function parseArgs(argv) {
 function printHelp() {
   process.stdout.write(
     [
-      'genie sec remediate — reversible, auditable host-compromise remediation',
+      'aegis remediate — reversible, auditable host-compromise remediation',
       '',
       'Modes:',
       '  --dry-run --scan-report <path>           Generate plan from a scan JSON file',
@@ -967,7 +967,7 @@ async function applyPlan(options) {
   const sizeBytes = dirSizeBytes(runRoot);
   if (sizeBytes > 100 * 1024 * 1024) {
     process.stderr.write(
-      `\nWARNING: quarantine size ${(sizeBytes / 1024 / 1024).toFixed(1)}MB exceeds 100MB threshold. Run \`genie sec restore <id>\` once verified, or \`genie sec quarantine gc --older-than <duration>\` to release space.\n`,
+      `\nWARNING: quarantine size ${(sizeBytes / 1024 / 1024).toFixed(1)}MB exceeds 100MB threshold. Run \`aegis restore <id>\` once verified, or \`aegis quarantine gc --older-than <duration>\` to release space.\n`,
     );
   }
 
@@ -1039,7 +1039,7 @@ function printCompletionBanner({
 }) {
   const lines = [
     '',
-    '─── genie sec remediate complete ───',
+    '─── aegis remediate complete ───',
     `scan_id        : ${scanId}`,
     `quarantine id  : ${runTs}`,
     `quarantine dir : ${runRoot}`,
@@ -1047,11 +1047,11 @@ function printCompletionBanner({
     `audit log      : ${auditPath}`,
     `actions        : ${completed} completed, ${skipped} skipped, ${failed} failed`,
     '',
-    `Restore individual quarantine: genie sec restore ${runTs}`,
-    `Bulk undo:                     genie sec rollback ${scanId}`,
+    `Restore individual quarantine: aegis restore ${runTs}`,
+    `Bulk undo:                     aegis rollback ${scanId}`,
   ];
   if (resumeFile) {
-    lines.push(`Resume partial:                genie sec remediate --resume ${resumeFile}`);
+    lines.push(`Resume partial:                aegis remediate --resume ${resumeFile}`);
   }
   lines.push('');
   process.stdout.write(`${lines.join('\n')}\n`);
@@ -1084,13 +1084,13 @@ function runDryRun(options) {
     process.stdout.write(
       [
         '',
-        '─── genie sec remediate (dry-run) ───',
+        '─── aegis remediate (dry-run) ───',
         `scan_id    : ${plan.scan_id}`,
         `plan_id    : ${plan.plan_id}`,
         `actions    : ${plan.actions.length}`,
         `plan path  : ${planPath}`,
         '',
-        `Apply with: genie sec remediate --apply --plan ${planPath}`,
+        `Apply with: aegis remediate --apply --plan ${planPath}`,
         '',
       ].join('\n'),
     );
@@ -1517,7 +1517,7 @@ async function main() {
       process.stdout.write(
         [
           '',
-          '─── genie sec rollback complete ───',
+          '─── aegis rollback complete ───',
           `rollback_id    : ${summary.rollback_id}`,
           `scan_id        : ${summary.scan_id}`,
           `started_at     : ${summary.started_at}`,
@@ -1557,7 +1557,7 @@ async function main() {
       const eligibleSize = (summary.eligible_size_bytes / 1024).toFixed(1);
       const lines = [
         '',
-        '─── genie sec quarantine gc ───',
+        '─── aegis quarantine gc ───',
         `older_than        : ${summary.older_than}`,
         `eligible ids      : ${summary.eligible_ids.length}`,
         `eligible size     : ${eligibleSize} KB`,

--- a/scripts/aegis-scan.cjs
+++ b/scripts/aegis-scan.cjs
@@ -24,8 +24,8 @@
  *   node scripts/sec-scan.cjs
  *   node scripts/sec-scan.cjs --json
  *   node scripts/sec-scan.cjs --all-homes --root /srv --root /opt
- *   genie sec scan
- *   genie sec scan --json --all-homes
+ *   aegis scan
+ *   aegis scan --json --all-homes
  *
  * Exit codes:
  *   0 = no findings
@@ -959,7 +959,7 @@ function printHelp(stream) {
     `${`
 Usage:
   node scripts/sec-scan.cjs [options]
-  genie sec scan [options]
+  aegis scan [options]
 
 Options:
   --json                       Print JSON envelope to stdout
@@ -986,8 +986,8 @@ Exit codes:
 
 Examples:
   node scripts/sec-scan.cjs --json
-  genie sec scan --all-homes --redact --events-file /tmp/scan.jsonl
-  GENIE_SEC_SCAN_DISABLED=1 genie sec scan   # kill switch, exits 0
+  aegis scan --all-homes --redact --events-file /tmp/scan.jsonl
+  GENIE_SEC_SCAN_DISABLED=1 aegis scan   # kill switch, exits 0
 `.trim()}\n`,
   );
 }
@@ -3141,7 +3141,7 @@ function scanLiveProcesses(report) {
     const [, pid, ppid, user, elapsed, command] = match;
 
     // Self-exclusion: the running scanner + any wrapping shell that invoked
-    // it (e.g. `bash -c "npx @automagik/genie sec scan …"`) will always
+    // it (e.g. `bash -c "aegis scan …"`) will always
     // match the tracked-package regexes in their own cmdline. Ignore both.
     if (String(pid) === String(process.pid)) continue;
     if (String(pid) === String(process.ppid)) continue;

--- a/test/remediator.test.ts
+++ b/test/remediator.test.ts
@@ -815,8 +815,8 @@ describe('sec-remediate completion banner + disk warning', () => {
       env(homeDir),
     );
     expect(apply.status).toBe(0);
-    expect(apply.stdout).toContain('genie sec restore');
-    expect(apply.stdout).toMatch(new RegExp(`genie sec rollback ${scanId}`));
+    expect(apply.stdout).toContain('aegis restore');
+    expect(apply.stdout).toMatch(new RegExp(`aegis rollback ${scanId}`));
   });
 
   test('apply emits stderr warning when quarantine exceeds 100MB', async () => {
@@ -844,7 +844,7 @@ describe('sec-remediate completion banner + disk warning', () => {
     );
     expect(apply.status).toBe(0);
     expect(apply.stderr).toMatch(/WARNING: quarantine size \d+(\.\d+)?MB exceeds 100MB threshold/);
-    expect(apply.stderr).toContain('genie sec quarantine gc');
+    expect(apply.stderr).toContain('aegis quarantine gc');
   }, 15_000);
 });
 


### PR DESCRIPTION
Round-2 review found 50 residual 'genie sec' strings across 7 files. All swept here.

## Files swept
- scripts/aegis-scan.cjs (6)
- scripts/aegis-remediate.cjs (16)
- scripts/aegis-fix.cjs (12)
- docs/security/key-rotation.md (7)
- docs/incident-response/canisterworm.md (4)
- .github/ISSUE_TEMPLATE/signing-key-fingerprint.md (2)
- test/remediator.test.ts (3 — paired with cjs-payload banner update)

## Intentional non-changes
- README/package.json genealogy notes (correct history)
- Cross-repo reference to genie wish (correct, wish lives there)
- @automagik/genie@<compromised-version> IOC references (the threat, not branding)

## Validation
- typecheck clean, 129 tests pass, dist/cli.js 103.85 KB
- Final grep for 'genie sec ' across docs/code returns zero outside bun.lock/dist

Ready for v0.1.0 tag after merge.

🤖 Generated with Claude Code