### PR TITLE
test(installer): cross-distro smoke harness + troubleshooting docs + shellcheck CI gate

### DIFF
--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -1,0 +1,74 @@
+name: Install Smoke Test
+
+# Validates the installer end-to-end on every supported Linux distro.
+# Triggers only on PRs that touch install.sh, the Dockerfiles, the harness
+# script, or this workflow itself — no point running this on every doc PR.
+#
+# Pipeline:
+#   1. shellcheck install.sh + scripts/test-install.sh (treat warnings as
+#      errors). This is the cheap fast gate; if the installer doesn't pass
+#      shellcheck, fail before spinning up any containers.
+#   2. Build + run each distro's container in a matrix. Each leg runs the
+#      local install.sh against the pinned release version with
+#      --auto-install-deps and asserts `aegis --version` reports the bare
+#      version string. Logs are captured per-leg so a single distro failure
+#      does not hide problems on the others.
+
+on:
+  pull_request:
+    paths:
+      - install.sh
+      - test/install/**
+      - scripts/test-install.sh
+      - .github/workflows/install-smoke-test.yml
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to install (must already exist on GitHub Releases)
+        required: false
+        default: v0.1.0
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck (warnings = errors)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        run: |
+          shellcheck --severity=warning install.sh
+          shellcheck --severity=warning scripts/test-install.sh
+
+  smoke:
+    name: smoke / ${{ matrix.distro }}
+    needs: shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - ubuntu-24
+          - debian-12
+          - fedora-40
+          - archlinux
+          - alpine-3.19
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve installer version
+        id: ver
+        run: |
+          version="${{ github.event.inputs.version }}"
+          if [ -z "$version" ]; then
+            version="v0.1.0"
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+      - name: Run smoke test for ${{ matrix.distro }}
+        env:
+          AEGIS_TEST_VERSION: ${{ steps.ver.outputs.version }}
+          AEGIS_TEST_DISTROS: ${{ matrix.distro }}
+        run: bash scripts/test-install.sh

--- a/README.md
+++ b/README.md
@@ -22,8 +22,16 @@ This pulls the latest signed release from GitHub Releases, verifies the cosign s
 
 Requirements on your machine:
 - `curl`, `tar`, `bash`, `node >= 20`
-- `cosign` — install from https://github.com/sigstore/cosign/releases (required by default; bypass with `--skip-verify` for air-gapped)
-- `slsa-verifier` — optional, adds the SLSA layer check
+- `cosign` — **the installer offers to install this for you** via your system's package manager (`brew` / `apt-get` / `dnf` / `yum` / `pacman` / `apk` / `nix`) on first run. Decline if you'd rather install it yourself from https://github.com/sigstore/cosign/releases. Bypass entirely with `--skip-verify` for air-gapped mirrors.
+- `slsa-verifier` — optional. Installer offers to install (default N) for the full 3-layer attestation check; declining is fine.
+
+For unattended installs (CI, Dockerfiles, provisioning scripts), pass `--auto-install-deps` to skip the prompts:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/automagik-dev/aegis/main/install.sh | bash -s -- --auto-install-deps
+```
+
+Hit a snag? See [`docs/install/troubleshooting.md`](docs/install/troubleshooting.md) for the five common failure modes (no pkg manager, sudo denied, cosign install failure, air-gapped, Windows).
 
 Alternative installers in [`docs/install/`](docs/install/):
 - **No-verify air-gap install** — for mirrors/offline

--- a/docs/install/npm-advanced.md
+++ b/docs/install/npm-advanced.md
@@ -71,6 +71,8 @@ The auth token line (`//npm.pkg.github.com/:_authToken=...`) is host-scoped — 
 | `npm ERR! 404 Not Found` | Scope line missing from `.npmrc` (npm tried npmjs.com instead) |
 | PAT works locally but not in CI | CI is using a different identity — set `NODE_AUTH_TOKEN` to a workflow-scoped token |
 
+For installer-script failure modes (no pkg manager, sudo denied, cosign install failures, air-gapped hosts, Windows), see [`troubleshooting.md`](troubleshooting.md).
+
 ## Why GitHub Packages at all?
 
 See the main README's "Why GitHub Releases + installer, not npmjs.com" section. Short version: `aegis` ships its tarball to GitHub Packages as a **secondary** path (the primary is the installer script) so that power users and CI systems can pin versions via `package.json` without losing the triple-attested release chain.

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -1,0 +1,251 @@
+# Install troubleshooting
+
+The aegis installer (`install.sh`) tries hard to "just work" on macOS and the
+big-five Linux distros. This page collects the known failure modes when it
+doesn't — what you see, why it happens, and the fix.
+
+> **TL;DR escape hatches:**
+> `--auto-install-deps` (assume Y, unattended), `--no-install-deps` (refuse to
+> mutate the host), `--skip-verify` (air-gapped only — bypasses cosign + SLSA).
+
+---
+
+## 1. "No package manager detected"
+
+**Symptom.** Installer prints something like:
+
+```
+✗ cosign not on PATH and no supported package manager detected
+  (brew/apt-get/dnf/yum/pacman/apk/nix). Install from
+  https://github.com/sigstore/cosign/releases or rerun with --skip-verify.
+```
+
+**Cause.** You're on a distro the installer doesn't probe — common cases are
+Void Linux, Gentoo, Slackware, the BSDs, custom Buildroot images, or a stripped
+container that removed its package manager. The installer refuses to guess
+because the wrong guess could mutate the wrong package database.
+
+**Fix — recommended.** Install cosign manually from the upstream Sigstore
+release page, then re-run the installer:
+
+```bash
+# Linux x64 — adjust for your arch as needed.
+curl -fsSL -o cosign \
+  https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
+chmod +x cosign
+sudo mv cosign /usr/local/bin/
+curl -fsSL https://raw.githubusercontent.com/automagik-dev/aegis/main/install.sh | bash
+```
+
+**Fix — last resort.** If you can't or won't install cosign, run the installer
+with `--skip-verify`. This bypasses cosign **and** SLSA verification, so the
+binary is no longer cryptographically attested. Only acceptable for air-gapped
+mirrors with out-of-band verification:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/automagik-dev/aegis/main/install.sh \
+  | bash -s -- --skip-verify
+```
+
+---
+
+## 2. Sudo denied / password prompt timed out
+
+**Symptom.** On Linux, the installer offers to run something like
+`sudo -E apt-get install -y cosign`, but `sudo` rejects you (`a password is
+required`, `user is not in the sudoers file`, or the prompt times out).
+
+**Cause.** Your account doesn't have sudo, or your sudo session has expired
+and the `curl | bash` pipeline can't read your password from a tty.
+
+**Fix.** Two options.
+
+1. **Re-run the installer with `--no-install-deps`** so it never attempts a
+   privileged install, then install cosign yourself with whatever path your
+   org provides (admin help, package mirror, manual tarball):
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/automagik-dev/aegis/main/install.sh \
+     | bash -s -- --no-install-deps
+   ```
+
+   This will exit with a clear message telling you to install cosign first.
+   Once cosign is on `PATH`, re-run the installer normally.
+
+2. **Install cosign in a directory you own** (no sudo needed) — see the
+   manual cosign install snippet in section 1 but drop the `sudo mv` and
+   put the binary somewhere on your `$PATH`, e.g. `~/.local/bin/cosign`.
+
+---
+
+## 3. cosign install failed (network, repo down, 404)
+
+**Symptom.** The installer runs the offered package-manager command and the
+package manager fails. You see something like:
+
+```
+==> Installing cosign via apt-get...
+E: Unable to locate package cosign
+✗ cosign install failed via apt-get. Re-run after fixing, or rerun with
+  --skip-verify (not recommended).
+```
+
+**Cause.** Common reasons:
+
+- The mirror you're pointing at doesn't ship `cosign` (older Debian/Ubuntu
+  before backports, or stale Alpine mirrors).
+- Network is being filtered by a corporate proxy.
+- The upstream repo is genuinely down at the moment.
+
+**Fix.**
+
+1. **Read the package manager's stderr above the aegis error line.** The
+   installer streams the underlying tool's output unchanged so you can see
+   exactly which mirror / URL failed. That message is almost always the
+   actionable signal.
+2. **Update your package index and retry.** `sudo apt-get update`,
+   `sudo dnf makecache`, `pacman -Syy`, or `apk update` — then re-run the
+   aegis installer.
+3. **Fall back to manual cosign install.** Use the upstream Sigstore release
+   tarball — see section 1.
+4. **Still stuck?** File an issue at
+   https://github.com/automagik-dev/aegis/issues with the full installer
+   output (redact anything sensitive). Include your distro name + version
+   (`cat /etc/os-release`) and which package manager fired.
+
+---
+
+## 4. Air-gapped machine (no internet to npm, GitHub, or Sigstore)
+
+**Symptom.** None of `curl | bash`, package manager installs, or cosign
+verification can reach the network. The installer's `--auto-install-deps`
+path is unusable because there's no upstream to pull from.
+
+**Cause.** You're behind a strict egress firewall, on a classified network,
+on a build farm with no DNS, or testing in a hermetic CI environment.
+
+**Fix — sneakernet the tarball.**
+
+1. **On a connected host, download the signed release assets:**
+
+   ```bash
+   VERSION=v0.1.0
+   REPO=automagik-dev/aegis
+   BASE=https://github.com/$REPO/releases/download/$VERSION
+   curl -fsSL -O "$BASE/automagik-dev-aegis-${VERSION#v}.tgz"
+   curl -fsSL -O "$BASE/automagik-dev-aegis-${VERSION#v}.tgz.sig"
+   curl -fsSL -O "$BASE/automagik-dev-aegis-${VERSION#v}.tgz.cert"
+   curl -fsSL -O "$BASE/provenance.intoto.jsonl"
+   curl -fsSL -O "$BASE/install.sh"
+   ```
+
+2. **Verify out-of-band on the connected host** (this is the moment to use
+   cosign + slsa-verifier with full network access):
+
+   ```bash
+   cosign verify-blob \
+     --certificate-identity-regexp "^https://github.com/$REPO/\\.github/workflows/release\\.yml@" \
+     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+     --signature "automagik-dev-aegis-${VERSION#v}.tgz.sig" \
+     --certificate "automagik-dev-aegis-${VERSION#v}.tgz.cert" \
+     "automagik-dev-aegis-${VERSION#v}.tgz"
+   ```
+
+3. **Copy the verified bundle** to the air-gapped host (USB, internal mirror,
+   approved transfer mechanism — this is the "sneakernet" step).
+
+4. **Run the installer with `--skip-verify`** because the air-gapped host
+   cannot reach Sigstore / Fulcio / Rekor:
+
+   ```bash
+   bash install.sh --skip-verify --version "$VERSION"
+   ```
+
+   The installer will look for the tarball at the expected GitHub URL. For a
+   fully offline workflow, host the bundle on an internal HTTP mirror and
+   override `REPO` / use a custom installer fork that points at it. Document
+   that override in your internal SOP — out of scope for the upstream
+   installer.
+
+---
+
+## 5. Windows users
+
+**Status.** Native Windows is **not** currently supported. The installer is a
+POSIX shell script and assumes `bash`, `curl`, `tar`, `node`, `cosign` — none
+of which ship as a coherent set on stock Windows.
+
+**Fix today — use WSL.** Install Windows Subsystem for Linux (Ubuntu image is
+fine), then follow the standard Linux install path inside the WSL shell:
+
+```bash
+# Inside WSL Ubuntu/Debian shell:
+curl -fsSL https://raw.githubusercontent.com/automagik-dev/aegis/main/install.sh | bash
+```
+
+The `aegis` binary lands inside the WSL filesystem at `~/.aegis/`. From PowerShell
+you can invoke it via `wsl aegis scan ...`.
+
+**Future — native PowerShell installer.** A native Windows installer is
+tracked in https://github.com/automagik-dev/aegis/issues (search for
+"PowerShell installer"). Until that lands, WSL is the supported path.
+
+---
+
+## Appendix: macOS manual smoke-test playbook
+
+CI does not test macOS (no public Apple Silicon runners that support docker).
+Each release candidate is verified manually using this checklist. Run on a
+fresh user account (not your daily driver) so you exercise the "no cosign yet"
+prompt path.
+
+Step-by-step:
+
+1. **Confirm a clean baseline.** `which cosign` should print nothing. If you
+   already have cosign, `brew uninstall cosign` first.
+2. **Install Homebrew if missing.**
+
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+
+3. **Install Node 22 (>=20 required).**
+
+   ```bash
+   brew install node@22
+   ```
+
+4. **Run the aegis installer.**
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/automagik-dev/aegis/main/install.sh | bash
+   ```
+
+   - Expected: prompt "cosign not on PATH. Will run: `brew install cosign`. [Y/n]" — accept.
+   - brew installs cosign in <60s.
+   - Optional slsa-verifier prompt fires next (default N — decline).
+   - Installer downloads the tarball, verifies the cosign signature, extracts
+     to `~/.aegis/v0.1.0/`, and symlinks `~/.local/bin/aegis`.
+
+5. **Verify the install.**
+
+   ```bash
+   command -v aegis
+   aegis --version            # should print 0.1.0 (or the pinned version)
+   aegis verify-install       # cosign + SLSA re-verified against the binary
+   ```
+
+6. **Clean up (optional).**
+
+   ```bash
+   rm -rf ~/.aegis ~/.local/bin/aegis
+   brew uninstall cosign
+   ```
+
+If step 4 prompts unexpectedly, hangs, or the installer fails — open an issue
+with the full transcript.
+
+---
+
+For npm / GitHub Packages install issues (the secondary distribution path),
+see [`npm-advanced.md`](npm-advanced.md).

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# aegis installer cross-distro smoke test.
+#
+# Builds a minimal docker image per supported Linux distro, runs the local
+# install.sh inside the container with --auto-install-deps (non-interactive),
+# and asserts `aegis --version` reports the expected release.
+#
+# Usage:
+#   bash scripts/test-install.sh                          # all distros, default version
+#   bash scripts/test-install.sh --version v0.1.1         # pin a different release
+#   bash scripts/test-install.sh --distros ubuntu-24,alpine-3.19
+#   bash scripts/test-install.sh --skip-verify            # bypass cosign on every run
+#   bash scripts/test-install.sh --help
+#
+# Environment overrides (flags win over env):
+#   AEGIS_TEST_VERSION   release tag passed to install.sh (default: v0.1.0)
+#   AEGIS_TEST_DISTROS   comma-separated subset of distros to run
+#   AEGIS_TEST_SKIP_VERIFY=1  pass --skip-verify to the in-container installer
+#
+# Exit codes:
+#   0  every selected distro passed
+#   1  one or more distros failed (last 20 lines printed for each failure)
+#   2  invocation error (bad flag, missing docker)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCKERFILE_DIR="$REPO_ROOT/test/install"
+
+ALL_DISTROS=(ubuntu-24 debian-12 fedora-40 archlinux alpine-3.19)
+
+VERSION="${AEGIS_TEST_VERSION:-v0.1.0}"
+DISTROS_CSV="${AEGIS_TEST_DISTROS:-}"
+SKIP_VERIFY="${AEGIS_TEST_SKIP_VERIFY:-0}"
+
+usage() {
+  sed -n '3,24p' "$0" | sed 's/^# \?//'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)     VERSION="$2"; shift 2 ;;
+    --distros)     DISTROS_CSV="$2"; shift 2 ;;
+    --skip-verify) SKIP_VERIFY=1; shift ;;
+    --help|-h)     usage; exit 0 ;;
+    *) printf 'test-install: unknown flag: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# Resolve the list of distros to run from CSV, validating each entry against
+# ALL_DISTROS so a typo fails loudly instead of silently doing nothing.
+declare -a DISTROS=()
+if [ -n "$DISTROS_CSV" ]; then
+  IFS=',' read -r -a requested <<< "$DISTROS_CSV"
+  for d in "${requested[@]}"; do
+    found=0
+    for known in "${ALL_DISTROS[@]}"; do
+      if [ "$d" = "$known" ]; then
+        found=1
+        break
+      fi
+    done
+    if [ "$found" -ne 1 ]; then
+      printf 'test-install: unknown distro: %s\n' "$d" >&2
+      printf 'known distros: %s\n' "${ALL_DISTROS[*]}" >&2
+      exit 2
+    fi
+    DISTROS+=("$d")
+  done
+else
+  DISTROS=("${ALL_DISTROS[@]}")
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  printf 'test-install: docker is not installed or not on PATH.\n' >&2
+  printf 'Install docker (https://docs.docker.com/engine/install/) and re-run.\n' >&2
+  exit 2
+fi
+
+# Trim leading "v" from the version once for the bare-version assertion.
+VERSION_BARE="${VERSION#v}"
+
+# Pretty-print helpers. Plain ASCII glyphs so the output is grep-friendly.
+c_info() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+c_ok()   { printf '\033[1;32m[ok]\033[0m %s\n' "$*"; }
+c_fail() { printf '\033[1;31m[fail]\033[0m %s\n' "$*" >&2; }
+
+declare -a RESULTS=()
+declare -a DURATIONS=()
+OVERALL_RC=0
+
+run_one() {
+  local distro="$1"
+  local dockerfile="$DOCKERFILE_DIR/Dockerfile.$distro"
+  local image="aegis-install-test:$distro"
+
+  if [ ! -f "$dockerfile" ]; then
+    c_fail "$distro: Dockerfile not found at $dockerfile"
+    RESULTS+=("FAIL")
+    DURATIONS+=("0")
+    OVERALL_RC=1
+    return
+  fi
+
+  c_info "[$distro] building image"
+  local build_log
+  build_log="$(mktemp)"
+  if ! docker build -t "$image" -f "$dockerfile" "$REPO_ROOT" >"$build_log" 2>&1; then
+    c_fail "$distro: docker build failed (last 20 lines):"
+    tail -n 20 "$build_log" >&2 || true
+    rm -f "$build_log"
+    RESULTS+=("FAIL")
+    DURATIONS+=("0")
+    OVERALL_RC=1
+    return
+  fi
+  rm -f "$build_log"
+
+  # Compose the in-container command. install.sh is bind-mounted at
+  # /work/install.sh so we don't have to bake a copy into every image.
+  local installer_args=(--auto-install-deps --version "$VERSION")
+  if [ "$SKIP_VERIFY" = "1" ]; then
+    installer_args+=(--skip-verify)
+  fi
+
+  # Quote the version for shell interpolation inside the container's bash -c.
+  local in_container_cmd
+  in_container_cmd=$(cat <<EOF
+set -e
+bash /work/install.sh ${installer_args[*]}
+export PATH="\$HOME/.local/bin:\$PATH"
+ver="\$(aegis --version 2>/dev/null || true)"
+printf 'aegis-version-output: %s\n' "\$ver"
+case "\$ver" in
+  *"$VERSION_BARE"*) exit 0 ;;
+  *) printf 'aegis --version did not contain %s (got: %s)\n' "$VERSION_BARE" "\$ver" >&2; exit 1 ;;
+esac
+EOF
+)
+
+  c_info "[$distro] running installer"
+  local run_log
+  run_log="$(mktemp)"
+  local started ended duration
+  started=$(date +%s)
+  if docker run --rm \
+        -v "$REPO_ROOT/install.sh:/work/install.sh:ro" \
+        "$image" \
+        bash -c "$in_container_cmd" >"$run_log" 2>&1; then
+    ended=$(date +%s)
+    duration=$((ended - started))
+    c_ok "$distro: aegis --version reports $VERSION_BARE (took ${duration}s)"
+    RESULTS+=("OK")
+    DURATIONS+=("$duration")
+  else
+    ended=$(date +%s)
+    duration=$((ended - started))
+    c_fail "$distro: installer or version check failed (last 20 lines):"
+    tail -n 20 "$run_log" >&2 || true
+    RESULTS+=("FAIL")
+    DURATIONS+=("$duration")
+    OVERALL_RC=1
+  fi
+  rm -f "$run_log"
+}
+
+c_info "Testing aegis installer for version: $VERSION"
+c_info "Distros: ${DISTROS[*]}"
+
+for distro in "${DISTROS[@]}"; do
+  run_one "$distro"
+done
+
+# Summary table. distro | result | duration. Plain ASCII; pipe-delimited so
+# downstream tooling (grep / awk / CI annotations) parses cleanly.
+printf '\n'
+printf '%-14s | %-6s | %s\n' "distro" "result" "duration"
+printf -- '---------------+--------+---------\n'
+for i in "${!DISTROS[@]}"; do
+  local_distro="${DISTROS[$i]}"
+  local_result="${RESULTS[$i]}"
+  local_duration="${DURATIONS[$i]}s"
+  case "$local_result" in
+    OK)   glyph="ok" ;;
+    FAIL) glyph="FAIL" ;;
+    *)    glyph="$local_result" ;;
+  esac
+  printf '%-14s | %-6s | %s\n' "$local_distro" "$glyph" "$local_duration"
+done
+
+if [ "$OVERALL_RC" -ne 0 ]; then
+  printf '\nOne or more distros FAILED. See logs above.\n' >&2
+fi
+
+exit "$OVERALL_RC"

--- a/test/install/Dockerfile.alpine-3.19
+++ b/test/install/Dockerfile.alpine-3.19
@@ -1,0 +1,9 @@
+# aegis installer smoke test — Alpine 3.19
+# Fresh host with curl + tar + node + sudo, but NO cosign.
+# Alpine ships BusyBox tar; the installer's tar usage is portable.
+FROM alpine:3.19
+
+RUN apk add --no-cache \
+        bash ca-certificates curl nodejs npm sudo tar
+
+WORKDIR /work

--- a/test/install/Dockerfile.archlinux
+++ b/test/install/Dockerfile.archlinux
@@ -1,0 +1,9 @@
+# aegis installer smoke test — Arch Linux
+# Fresh host with curl + tar + node + sudo, but NO cosign.
+FROM archlinux:latest
+
+RUN pacman -Sy --noconfirm \
+        bash ca-certificates curl nodejs npm sudo tar \
+ && pacman -Scc --noconfirm
+
+WORKDIR /work

--- a/test/install/Dockerfile.debian-12
+++ b/test/install/Dockerfile.debian-12
@@ -1,0 +1,14 @@
+# aegis installer smoke test — Debian 12 (bookworm)
+# Fresh host with curl + tar + node + sudo, but NO cosign.
+FROM debian:12
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        bash ca-certificates curl gnupg sudo tar \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work

--- a/test/install/Dockerfile.fedora-40
+++ b/test/install/Dockerfile.fedora-40
@@ -1,0 +1,9 @@
+# aegis installer smoke test — Fedora 40
+# Fresh host with curl + tar + node + sudo, but NO cosign.
+FROM fedora:40
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+        bash ca-certificates curl-minimal nodejs sudo tar \
+ && dnf clean all
+
+WORKDIR /work

--- a/test/install/Dockerfile.ubuntu-24
+++ b/test/install/Dockerfile.ubuntu-24
@@ -1,0 +1,16 @@
+# aegis installer smoke test — Ubuntu 24.04
+# Fresh host with curl + tar + node + sudo, but NO cosign.
+# The installer is expected to detect the missing cosign and offer to
+# install it via apt-get under --auto-install-deps.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        bash ca-certificates curl gnupg sudo tar \
+ && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work


### PR DESCRIPTION
## Summary

Group 3 (final) of the `install-auto-deps-resolve` wish — closes the loop after Groups 1 + 2 (PRs #7 + #8) shipped the auto-install flow + flags + slsa-verifier offer. Tests the installer end-to-end on every supported Linux distro, documents the failure modes, and keeps `install.sh` honest with a CI shellcheck gate.

- **Smoke harness** — `scripts/test-install.sh` builds 5 minimal Dockerfiles (`ubuntu-24` / `debian-12` / `fedora-40` / `archlinux` / `alpine-3.19`), runs the local `install.sh --auto-install-deps --version <tag>` inside each, asserts `aegis --version` reports the bare version. Per-distro failure logs, summary table at end. `--distros` for subsetting + `--skip-verify` passthrough + env overrides for CI.
- **CI workflow** — `.github/workflows/install-smoke-test.yml` triggers on PRs touching `install.sh`, the harness, or the Dockerfiles. shellcheck (warnings = errors) is the cheap gate; smoke matrix runs only after it passes. `workflow_dispatch` accepts a custom version tag.
- **Docs** — `docs/install/troubleshooting.md` (251 lines) walks through the five real failure modes: no pkg manager (Void/Gentoo/BSDs), sudo denied, cosign install failure, air-gapped sneakernet workflow, Windows / WSL pointer. Includes the macOS manual smoke-test playbook (CI doesn't cover Darwin). README "Install" section rewritten — no stale `brew install cosign` prereq, mentions `--auto-install-deps` for unattended use, links to troubleshooting.md. `npm-advanced.md` cross-links to troubleshooting.md.
- **`install.sh` untouched** — Group 1 + 2 shipped the behaviour; Group 3 is tests + docs + CI only.

## Test plan

- [x] `shellcheck --severity=warning install.sh` clean
- [x] `shellcheck --severity=warning scripts/test-install.sh` clean
- [x] `bash -n scripts/test-install.sh` clean
- [x] `bash scripts/test-install.sh --help` prints usage
- [x] Bad flag / unknown distro → exit 2 with clear stderr
- [x] Missing-docker → exit 2 with install hint
- [x] README has no `brew install cosign` regression (grep clean)
- [x] All 5 Dockerfiles < 20 lines
- [x] `troubleshooting.md` < 300 lines (251)
- [x] `npm-advanced.md` cross-links to `troubleshooting.md`
- [ ] CI: `install-smoke-test.yml` runs on this PR — first live cross-distro smoke matrix (will surface here)
- [ ] Manual: docker-enabled host runs `bash scripts/test-install.sh` end-to-end against `v0.1.0` (deferred — local sandbox has no docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)