### PR TITLE
fix(build): add shebang to dist/cli.js so installed binary actually executes (v0.1.2 hotfix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik-dev/aegis",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "npm supply-chain incident-response CLI — scan, fix, remediate, verify. Published via GitHub Packages only (trust-model decision after the April 2026 CanisterWorm incident). Spun out of @automagik/genie sec.",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
@@ -11,7 +11,7 @@
     "aegis": "./dist/cli.js"
   },
   "scripts": {
-    "build": "bun build src/cli/index.ts --target=node --outfile=dist/cli.js",
+    "build": "bun build src/cli/index.ts --target=node --outfile=dist/cli.js --banner='#!/usr/bin/env node' && chmod +x dist/cli.js",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "lint": "biome check src",


### PR DESCRIPTION
## Critical bug
v0.1.0 + v0.1.1 shipped without `#!/usr/bin/env node` at the top of `dist/cli.js`. When install.sh symlinks `~/.local/bin/aegis` at the bundle, executing falls through to `/bin/sh`, which chokes on the first `import`:

```
/Users/feliperosa/.local/bin/aegis: line 1: import: command not found
/Users/feliperosa/.local/bin/aegis: line 7: syntax error near unexpected token `key'
```

Reported by Felipe on darwin/arm64 immediately after v0.1.1 install. Every install of v0.1.0 + v0.1.1 is broken at runtime.

## Fix
- `package.json` build script: `bun build ... --banner='#!/usr/bin/env node' && chmod +x dist/cli.js`
- Bumped version to 0.1.2

## Validation
- bun run build → dist/cli.js with shebang on line 1
- ./dist/cli.js --version → 0.1.2 (executes via node, not /bin/sh)
- typecheck clean, 129 tests pass

Trust chain unchanged. Purely a runtime-execution shebang hotfix.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.2.
  * Improved CLI build configuration for better command-line execution support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->